### PR TITLE
Noskov Andrey 18AMI

### DIFF
--- a/andrey_noskov/ReadMe.txt
+++ b/andrey_noskov/ReadMe.txt
@@ -1,0 +1,4 @@
+In this case I used only 25% of whole farfield data. My result:
+	- initial WER (word error rate) was 0.66 without post-training
+	- WER became 0.57 
+Now model is training on the whole dataset, if Colab's GPU will not shut down, I will attach new results


### PR DESCRIPTION
In this case I used only 25% of whole farfield data. My result:
	- initial WER (word error rate) was 0.66 without post-training
	- **current WER is 0.57** 
Now model is training on the whole dataset, if Colab's GPU will not shut down, I will attach new results